### PR TITLE
Remove leading slash in gitignore entry for

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /vendor/
-/composer.lock
+composer.lock
 .log


### PR DESCRIPTION
composer.lock

The leading slash before "composer.lock" in the gitignore rules has been removed. This change ensures that the composer.lock file will be ignored correctly. The removal of the slash allows the gitignore rule to match the composer.lock file in all directories. Mismatched slashes could cause the composer.lock file to be included in the repository inadvertently, leading to potential version conflicts and inconsistency across deployments.

No issues related to this change are mentioned.

Notice that the reference to the specific gitignore file (".gitignore") is crucial in understanding the changes made.