### PR TITLE
Restructure route configuration to remove

### DIFF
--- a/routes/route.php
+++ b/routes/route.php
@@ -12,7 +12,7 @@ include dirname(__DIR__) . '/vendor/autoload.php';
  *  |   The parameter contains only be a boolean, which indicates request logger to prints out logs output on each received request 
  *  ---------------------------------------------------------------------------------------------------------------------------
  */
-Route::config(true);
+Route::config();
 
 
 /**


### PR DESCRIPTION
unnecessary boolean argument

The commit removes the boolean argument passed to the `Route::config()` function in the `routes/route.php` file. This change is made to simplify the configuration process and avoid potential confusion caused by the presence of an unused argument. No issues are addressed in this commit.