### PR TITLE
Updated to version v1.2.1-alpha pre-release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "dconco/php_slides",
     "description": "PhpSlides a light fast framework for letting you create a secured Routing in php and secured API, which prevents SQL injections, and from XSS attack & CSRF.",
     "homepage": "https://github.com/dconco/php_slides",
-    "version": "v1.2.1-alpha",
+    "version": "1.2.1-alpha",
     "type": "project",
     "keywords": [
         "php",


### PR DESCRIPTION
Updated to version v1.2.1-alpha pre-release

- Fix Error and Bugs in `slides_include()`
- Make `<? ?>` slides php tag to be more effective. 
- `@view` in the slides php tag are now `deprecated` at version 1.2.1 pre-release and latest.
- Make all the `<include !/>` elements be more effective 
- All <include !/>` elements will be replaced with `slides_include()`
- Added Short Icon
- Updated Short Icon url in `Header.php`
- Arrange styles in `App.css` to `Header.php`

- Now auto generating `bin` folder with the files in `App` directory.
- Can now define a constant in `web.php` and use it in `api.php` which is available from version 1.2.1 and upcoming latest versions.

- From version 1.2.1 can no longer use the same class namespace for routes and api. 
- Make `ApiController.php` to accept `integer` as it's method parameter and `string` types are now `deprecated`.
- `ApiController.php` method parameter now accepts interger constant.